### PR TITLE
Fixed user cannot start checkout process with engraving text empty

### DIFF
--- a/app/views/spree/orders/_customization_cart.html.erb
+++ b/app/views/spree/orders/_customization_cart.html.erb
@@ -1,5 +1,5 @@
 <% if line_item.preferred_customization %>
-		
+
 	<div>
 		<b>Your Engraving: </b><small>(please hit 'Update' if you change it)</small>
 		<% customization_data = JSON.parse(line_item.preferred_customization) %>
@@ -26,11 +26,11 @@
 			engravingGuard = true;
 		}
 	}
-	
+
 	// check that at least one line of engraving data has been entered, before commencing to checkout
 	$(document).ready(function() {
 		$('#checkout-link').click(function(e) {
-			if ($('[name="customization[data][line1]"]').val().length == 0) {
+			if ($('[name^="customization[data]"][name$="[line1]"]').val().length == 0) {
 				alert('Please enter at least the first line of your engraving data and update the cart.');
 				e.preventDefault();
 			}


### PR DESCRIPTION
User should not be able to start checkout process until they have entered text for an engravable item in their cart.
